### PR TITLE
Fix : Token전달용 JSON에서 initialLogin 삭제

### DIFF
--- a/src/main/java/com/sparta/hh99_actualproject/dto/TokenDto.java
+++ b/src/main/java/com/sparta/hh99_actualproject/dto/TokenDto.java
@@ -7,7 +7,6 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TokenDto {
-    private boolean initialLogin;
     private String accessToken;
     private String refreshToken;
 }

--- a/src/main/java/com/sparta/hh99_actualproject/service/KakaoUserService.java
+++ b/src/main/java/com/sparta/hh99_actualproject/service/KakaoUserService.java
@@ -150,12 +150,10 @@ public class KakaoUserService {
 
         TokenDto tokenDto;
 
-        boolean isInitialLogin = (kakaoUser.getNickname() == null); //kakaoUser.getNickname()가 Null 이면 최초 로그인
         //TODO : refreshToken 구현 필요
         String accessToken = tokenProvider.createAccessToken(authentication.getName(),kakaoUser.getNickname());
 
         tokenDto = TokenDto.builder()
-                .initialLogin(isInitialLogin)
                 .accessToken(accessToken)
                 .build();
 

--- a/src/main/java/com/sparta/hh99_actualproject/service/MemberService.java
+++ b/src/main/java/com/sparta/hh99_actualproject/service/MemberService.java
@@ -60,13 +60,11 @@ public class MemberService {
 
         Member findedMember = memberRepository.findByMemberId(memberRequestDto.getMemberId())
                 .orElseThrow(() -> new PrivateException(StatusCode.NOT_FOUND_MEMBER));
-        boolean isInitialLogin = (findedMember.getNickname() == null); //findedMember.getNickname()가 Null 이면 최초 로그인
 
         //TODO : refreshToken 구현 필요
         String accessToken = tokenProvider.createAccessToken(authentication.getName(),findedMember.getNickname());
 
         tokenDto = TokenDto.builder()
-                .initialLogin(isInitialLogin)
                 .accessToken(accessToken)
                 .build();
 
@@ -87,7 +85,6 @@ public class MemberService {
         String accessToken = tokenProvider.createAccessToken(findedMember.getMemberId(),findedMember.getNickname());
 
         tokenDto = TokenDto.builder()
-                .initialLogin(false)
                 .accessToken(accessToken)
                 .build();
 


### PR DESCRIPTION
initialLogin 을 사용하지 않아도 최초 로그인 구분이 가능하므로 initialLogin 삭제